### PR TITLE
Migrated from `onRequestClose` to `onClose`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
     "gh-pages": "^1.0.0",
-    "material-ui": "^1.0.0-beta.20",
+    "material-ui": "^1.0.0-beta.24",
     "react": "^16.1.0",
     "react-dom": "^16.1.0",
     "react-styleguidist": "^5.5.9",
     "standard": "^10.0.2"
   },
   "peerDependencies": {
-    "material-ui": "^1.0.0-beta.20",
+    "material-ui": "^1.0.0-beta.24",
     "react": "^15.5.4 || ^16.0.0"
   },
   "dependencies": {

--- a/src/SnackbarProvider.js
+++ b/src/SnackbarProvider.js
@@ -32,11 +32,11 @@ export default class SnackbarProvider extends PureComponent {
   }
 
   handleActionClick = () => {
-    this.handleRequestClose()
+    this.handleClose()
     this.state.handleAction()
   }
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false, handleAction: null })
   }
 
@@ -65,7 +65,7 @@ export default class SnackbarProvider extends PureComponent {
               UNDO
             </Button>
           )}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
         />
       </div>
     )


### PR DESCRIPTION
This api change was introduced in the latest 1.0.0-beta.24. See https://github.com/mui-org/material-ui/pull/9451

* Renamed `onRequestClose` to `onClose`
* Bumped material-ui version number to latest beta.